### PR TITLE
fix: Specify extension kind UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   ],
   "activationEvents": [
     "onStartupFinished",
-    "onCommand:command-alias.createAliases"
   ],
   "main": "./src/extension.js",
   "contributes": {
@@ -54,7 +53,8 @@
     }
   },
   "extensionKind": [
-    "ui"
+    "ui",
+    "workspace"
   ],
   "scripts": {
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
       }
     }
   },
+  "extensionKind": [
+    "ui"
+  ],
   "scripts": {
     "lint": "eslint .",
     "pretest": "npm run lint",


### PR DESCRIPTION
Specifies that this is a UI extension, i.e. that it should run close to the UI in case of remote development.
This means it will run on the Windows side, rather than the Linux side if using vscode with WSL Remote Development.

Fixes #7

---

I didn't test it locally (I'm new to vscode extension development), but based on some research [^1][^2] I believe this should fix the error I encountered.

[^1]: https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location
[^2]: https://code.visualstudio.com/api/advanced-topics/extension-host#preferred-extension-location